### PR TITLE
Familymember checkbox conditional feature

### DIFF
--- a/sir-client/src/SirForm/SirForm.test.tsx
+++ b/sir-client/src/SirForm/SirForm.test.tsx
@@ -170,10 +170,12 @@ describe('SirForm', () => {
     expect(screen.getByRole('checkbox', { name: /individualsInvolved.familyMember/i })).toBeChecked();
   });
   it('accepts individualsInvolved.adult selection', () => {
+    userEvent.click(screen.getByTitle(/individualsInvolved.familyMember/i));
     userEvent.click(screen.getByTitle(/individualsInvolved.adult/i));
     expect(screen.getByRole('checkbox', { name: /individualsInvolved.adult/i })).toBeChecked();
   });
   it('accepts individualsInvolved.child selection', () => {
+    userEvent.click(screen.getByTitle(/individualsInvolved.familyMember/i));
     userEvent.click(screen.getByTitle(/individualsInvolved.child/i));
     expect(screen.getByRole('checkbox', { name: /individualsInvolved.child/i })).toBeChecked();
   });
@@ -192,6 +194,14 @@ describe('SirForm', () => {
   it('accepts individualsInvolved.other selection', () => {
     userEvent.click(screen.getByTitle(/individualsInvolved.other/i));
     expect(screen.getByRole('checkbox', { name: /individualsInvolved.other/i })).toBeChecked();
+  });
+
+  it('disables Adult and Child inputs until Family Member is checked', () => {
+    expect(screen.getByRole('checkbox', { name: /individualsInvolved.adult/i })).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: /individualsInvolved.child/i })).toBeDisabled();
+    userEvent.click(screen.getByTitle(/individualsInvolved.familyMember/i));
+    expect(screen.getByRole('checkbox', { name: /individualsInvolved.adult/i })).not.toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: /individualsInvolved.child/i })).not.toBeDisabled();
   });
 
   // Type of Event

--- a/sir-client/src/SirForm/SirForm.test.tsx
+++ b/sir-client/src/SirForm/SirForm.test.tsx
@@ -1,4 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent, render, screen, waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
@@ -204,6 +206,15 @@ describe('SirForm', () => {
     expect(screen.getByRole('checkbox', { name: /individualsInvolved.child/i })).not.toBeDisabled();
   });
 
+  it('conditionally unchecks Adult and Child inputs when Family Member is unchecked', () => {
+    userEvent.click(screen.getByTitle(/individualsInvolved.familyMember/i));
+    userEvent.click(screen.getByTitle(/individualsInvolved.adult/i));
+    userEvent.click(screen.getByTitle(/individualsInvolved.child/i));
+    userEvent.click(screen.getByTitle(/individualsInvolved.familyMember/i));
+    expect(screen.getByRole('checkbox', { name: /individualsInvolved.adult/i })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /individualsInvolved.child/i })).not.toBeChecked();
+  });
+
   // Type of Event
   it('accepts typeOfEvent string', () => {
     userEvent.type(screen.getByRole('textbox', { name: /type of event/i }), 'Adverse Drug Reaction, Medication Related');
@@ -292,13 +303,13 @@ describe('SirForm', () => {
     window.scrollTo = jest.fn();
     fillAllFields();
     userEvent.click(screen.getByRole('button', { name: /submit/i }));
-    await waitFor(() => { expect(window.scrollTo).toHaveBeenCalledTimes(1); });
-    const expectedY = 0;
-    const expectedX = 0;
-    const actualY = window.scrollY;
-    const actualX = window.scrollX;
-    expect(actualX).toBe(expectedX);
-    expect(actualY).toBe(expectedY);
+    await waitFor(() => { expect(window.scrollTo).toHaveBeenCalledWith({ behavior: 'smooth', top: 0 }); });
+    // const expectedY = 0;
+    // const expectedX = 0;
+    // const actualY = window.scrollY;
+    // const actualX = window.scrollX;
+    // expect(actualX).toBe(expectedX);
+    // expect(actualY).toBe(expectedY);
   });
   it('X button closes alert banner', async () => {
     fillAllFields();

--- a/sir-client/src/SirForm/SirForm.tsx
+++ b/sir-client/src/SirForm/SirForm.tsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { Formik, Field, Form } from 'formik';
 import * as Yup from 'yup';
 import CustomAlert, { AlertType } from '../Components/CustomAlert';
+import CustomCheckbox from '../Components/CustomCheckbox';
 
 interface Values {
     incidentDate: string;
@@ -80,6 +81,7 @@ function convertDate(date: Date): string {
 
 const SirForm: React.FC = () => {
   const [reportSubmitted, setReportSubmitted] = useState(false);
+  const [familyMemberCheck, setFamilyMemberCheck] = useState(false);
 
   // Set the back end address and port from environment variable REACT_APP_API_HOST if it is set,
   // otherwise, use the proxy settings in package.json.
@@ -90,6 +92,10 @@ const SirForm: React.FC = () => {
     axios.post(`${API_HOST}/api/incidents`, values)
       .then(() => setReportSubmitted(true));
     // .then(() => console.log(`Submitted report to ${API_HOST}/api/incidents`));
+  };
+
+  const handleFamilyMemberCheck = () => {
+    setFamilyMemberCheck(!familyMemberCheck);
   };
 
   return (
@@ -191,15 +197,25 @@ const SirForm: React.FC = () => {
                       Patient
                     </p>
                     <p>
-                      <Field type="checkbox" name="individualsInvolved.familyMember" title="individualsInvolved.familyMember" />
+                      <Field type="checkbox" name="individualsInvolved.familyMember" title="individualsInvolved.familyMember" onClick={handleFamilyMemberCheck} />
                       Family Member
                     </p>
-                    <p>
-                      <Field type="checkbox" name="individualsInvolved.adult" title="individualsInvolved.adult" />
+                    <p data-indent="yes" className={!familyMemberCheck ? 'disabled' : 'p'}>
+                      <Field
+                        type="checkbox"
+                        name="individualsInvolved.adult"
+                        title="individualsInvolved.adult"
+                        disabled={!familyMemberCheck}
+                      />
                       Adult
                     </p>
-                    <p>
-                      <Field type="checkbox" name="individualsInvolved.child" title="individualsInvolved.child" />
+                    <p data-indent="yes" className={!familyMemberCheck ? 'disabled' : 'p'}>
+                      <Field
+                        type="checkbox"
+                        name="individualsInvolved.child"
+                        title="individualsInvolved.child"
+                        disabled={!familyMemberCheck}
+                      />
                       Child less than 18 years old
                     </p>
                   </div>

--- a/sir-client/src/SirForm/SirForm.tsx
+++ b/sir-client/src/SirForm/SirForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { Formik, Field, Form } from 'formik';
 import * as Yup from 'yup';
@@ -197,7 +197,18 @@ const SirForm: React.FC = () => {
                       Patient
                     </p>
                     <p>
-                      <Field type="checkbox" name="individualsInvolved.familyMember" title="individualsInvolved.familyMember" onClick={handleFamilyMemberCheck} />
+                      <Field
+                        type="checkbox"
+                        name="individualsInvolved.familyMember"
+                        title="individualsInvolved.familyMember"
+                        onClick={() => {
+                          handleFamilyMemberCheck();
+                          if (formik.values.individualsInvolved.familyMember) {
+                            formik.setFieldValue('individualsInvolved.adult', false);
+                            formik.setFieldValue('individualsInvolved.child', false);
+                          }
+                        }}
+                      />
                       Family Member
                     </p>
                     <p data-indent="yes" className={!familyMemberCheck ? 'disabled' : 'p'}>

--- a/sir-client/src/Styles/Styles.css
+++ b/sir-client/src/Styles/Styles.css
@@ -476,6 +476,18 @@ tr {
 .checkbox[parent] {
   padding-left: 32px;
 }
+p[data-indent="yes"]{
+  margin-left: 20px;
+}
+p {
+  font-family: 'Public Sans', sans-serif;
+  margin: 4px 0px;
+
+}
+
+p.disabled{
+  opacity: 0.5;
+}
 
 .modal-container {
   display: flex;


### PR DESCRIPTION
We fixed the behavior of the checkboxes on the reporter view. We also made the SIRForm test more appropriate for scrolling to the top based on what scrollto is called with.