### PR TITLE
Added padding to convertDate()

### DIFF
--- a/sir-client/src/SirForm/SirForm.tsx
+++ b/sir-client/src/SirForm/SirForm.tsx
@@ -76,7 +76,9 @@ const incidentSchema = Yup.object().shape({
 });
 
 function convertDate(date: Date): string {
-  return `${date.getUTCFullYear()}-${date.getUTCMonth() + 1}-${date.getUTCDate()}`;
+  const today = `${date.getUTCFullYear()}-${date.getUTCMonth() + 1}-${date.getUTCDate().toString().padStart(2, '0')}`;
+  console.log(`Today is: ${today}`);
+  return today;
 }
 
 const SirForm: React.FC = () => {


### PR DESCRIPTION
Date of Event on Reporter (SirForm) defaults to today's date.

Trello: https://trello.com/c/BRCGdiuQ/44-bugfix-sirform-no-longer-auto-populates-todays-date